### PR TITLE
M095M01A-2 [MAGENTO 2] Add logging to rate limiting

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/RateLimiting/DisableRateLimiting.php
+++ b/Controller/Adminhtml/FastlyCdn/RateLimiting/DisableRateLimiting.php
@@ -159,6 +159,13 @@ class DisableRateLimiting extends Action
             );
 
             $this->configWriter->save(
+                Config::XML_FASTLY_RATE_LIMITING_LOGGING_ENABLE,
+                0,
+                'default',
+                '0'
+            );
+
+            $this->configWriter->save(
                 Config::XML_FASTLY_RATE_LIMITING_ENABLE,
                 0,
                 'default',

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -481,6 +481,12 @@ class Config extends \Magento\PageCache\Model\Config
         = 'system/full_page_cache/fastly/fastly_rate_limiting_settings/enable_rate_limiting_master';
 
     /**
+     * XML path to enable Rate Limiting
+     */
+    const XML_FASTLY_RATE_LIMITING_LOGGING_ENABLE
+        = 'system/full_page_cache/fastly/fastly_rate_limiting_settings/enable_rate_limiting_logging';
+
+    /**
      * XML path to enable Crawler Protection
      */
     const XML_FASTLY_CRAWLER_PROTECTION_ENABLE
@@ -980,6 +986,16 @@ class Config extends \Magento\PageCache\Model\Config
     public function isRateLimitingMasterEnabled()
     {
         return $this->_scopeConfig->getValue(self::XML_FASTLY_RATE_LIMITING_MASTER_ENABLE);
+    }
+
+    /**
+     * return Rate Limiting logging status
+     *
+     * @return mixed
+     */
+    public function isRateLimitingLoggingEnabled()
+    {
+        return $this->_scopeConfig->getValue(self::XML_FASTLY_RATE_LIMITING_LOGGING_ENABLE);
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -657,6 +657,13 @@
                             <label>Enable Rate Limiting</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         </field>
+                        <field id="enable_rate_limiting_logging" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInStore="0" showInWebsite="0">
+                            <label>Enable Rate Limit Logging</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <depends>
+                                <field id="enable_rate_limiting_master">1</field>
+                            </depends>
+                        </field>
                         <group id="path_protection" sortOrder="15" translate="label comment" showInDefault="1" showInWebsite="0" showInStore="0">
                             <label>Path Protection</label>
                             <!-- =================================

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -53,4 +53,21 @@
                 <argument name="authSession" xsi:type="object">Magento\Backend\Model\Auth\Session\Proxy</argument>
         </arguments>
     </type>
+    <virtualType name="Fastly\Cdn\Model\RateLimit\Logger\Info" type="Magento\Framework\Logger\Handler\Base">
+        <arguments>
+            <argument name="fileName" xsi:type="string">/var/log/fastly-rate-limit.log</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Fastly\Cdn\Model\RateLimit\Logger" type="Magento\Framework\Logger\Monolog">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="info" xsi:type="object">Fastly\Cdn\Model\RateLimit\Logger\Info</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <type name="Fastly\Cdn\Model\FrontControllerPlugin">
+        <arguments>
+            <argument name="logger" xsi:type="object">Fastly\Cdn\Model\RateLimit\Logger</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
- Add ´Enable Rate Limit Logging` config flag
- Add Logger virtual type with file `/var/log/fastly-rate-limit.log`
- Add multiple log calls to describe the process of rate limiting (both path and crawler scopes)