### PR TITLE
feature/M095M01A-6 [MAGENTO 2] Add couple logging end points

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/Logging/CreateEndpoint.php
+++ b/Controller/Adminhtml/FastlyCdn/Logging/CreateEndpoint.php
@@ -116,6 +116,7 @@ class CreateEndpoint extends Action
                 $this->getRequest()->getParam('log_endpoint'),
                 ['response_condition' => $condition]
             );
+            $params['format'] = json_encode($params['format']);
 
             $endpoint = $this->api->createLogEndpoint($clone->number, $endpointType, $params);
 

--- a/Controller/Adminhtml/FastlyCdn/Logging/GetEndpoint.php
+++ b/Controller/Adminhtml/FastlyCdn/Logging/GetEndpoint.php
@@ -77,6 +77,7 @@ class GetEndpoint extends Action
                 $this->getRequest()->getParam('type'),
                 $this->getRequest()->getParam('name')
             );
+            $endpoint->format = json_decode($endpoint->format);
 
             if (!$endpoint) {
                 return $result->setData([

--- a/Controller/Adminhtml/FastlyCdn/Logging/UpdateEndpoint.php
+++ b/Controller/Adminhtml/FastlyCdn/Logging/UpdateEndpoint.php
@@ -117,6 +117,7 @@ class UpdateEndpoint extends Action
                 $this->getRequest()->getParam('log_endpoint'),
                 ['response_condition' => $condition]
             );
+            $params['format'] = json_encode($params['format']);
 
             $endpoint = $this->api->updateLogEndpoint($clone->number, $endpointType, $params, $oldName);
 

--- a/view/adminhtml/templates/system/config/dialogs.phtml
+++ b/view/adminhtml/templates/system/config/dialogs.phtml
@@ -1015,7 +1015,37 @@
                     <span><?php /* @noEscape */ echo __("Log format") ?></span>
                 </label>
                 <div class="admin__field-control">
-                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text"></textarea>
+                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text">
+{
+	"time": "%{begin:%Y-%m-%dT%H:%M:%SZ}t",
+	"data": {
+		"service_id": "%{req.service_id}V",
+		"time_elapsed": "%D",
+		"request": "%m",
+		"host": "%{Fastly-Orig-Host}i",
+		"url": "%{cstr_escape(req.url)}V",
+		"protocol": "%H",
+		"is_ipv6": "%{if(req.is_ipv6, 'true', 'false')}V",
+		"is_tls": "%{if(req.is_ssl, 'true', 'false')}V",
+		"is_h2": "%{if(fastly_info.is_h2, 'true', 'false')}V",
+		"client_ip": "%h",
+		"geo_city": "%{client.geo.city.utf8}V",
+		"geo_country_code": "%{client.geo.country_code}V",
+		"server_datacenter": "%{server.datacenter}V",
+		"request_referer": "%{Referer}i",
+		"request_user_agent": "%{User-Agent}i",
+		"request_accept_content": "%{Accept}i",
+		"request_accept_language": "%{Accept-Language}i",
+		"request_accept_charset": "%{Accept-Charset}i",
+		"cache_status": "%{regsub(fastly_info.state, '^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*', '\\2\\3') }V",
+		"status": "%s",
+		"content_type": "%{Content-Type}o",
+		"req_header_size": "%{req.header_bytes_read}V",
+		"req_body_size": "%{req.body_bytes_read}V",
+		"resp_header_size": "%{resp.header_bytes_written}V",
+		"resp_body_size": "%{resp.body_bytes_written}V"
+	}
+}</textarea>
                     <div class="admin__field-note">
                         A suggested format string appears by default.
                         See <a target="_blank" href="https://docs.fastly.com/en/guides/setting-up-remote-log-streaming" rel="noopener noreferrer">Fastly's log files docs</a>,
@@ -1138,7 +1168,8 @@
                     <span><?php /* @noEscape */ echo __("Log format") ?></span>
                 </label>
                 <div class="admin__field-control">
-                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text"></textarea>
+                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text">
+"%h %l %u %t \"%r\" %>s %b"</textarea>
                     <div class="admin__field-note">
                         An Apache-style string or VCL variables to use for log formatting (the Apache Common Log format string appears by default).
                         See <a target="_blank" href="https://docs.fastly.com/en/guides/setting-up-remote-log-streaming" rel="noopener noreferrer" class="external-link">Fastly's log files docs</a>,
@@ -1266,7 +1297,23 @@
                     <span><?php /* @noEscape */ echo __("Log format") ?></span>
                 </label>
                 <div class="admin__field-control">
-                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text"></textarea>
+                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text">
+{
+	"timestamp": "%{begin:%Y-%m-%dT%H:%M:%S}t",
+	"time_elapsed": "%{time.elapsed.usec}V",
+	"is_tls": "%{if(req.is_ssl, 'true', 'false')}V",
+	"client_ip": "%{req.http.Fastly-Client-IP}V",
+	"geo_city": "%{client.geo.city}V",
+	"geo_country_code": "%{client.geo.country_code}V",
+	"request": "%{req.request}V",
+	"host": "%{req.http.Fastly-Orig-Host}V",
+	"url": "%{json.escape(req.url)}V",
+	"request_referer": "%{json.escape(req.http.Referer)}V",
+	"request_user_agent": "%{json.escape(req.http.User-Agent)}V",
+	"request_accept_language": "%{json.escape(req.http.Accept-Language)}V",
+	"request_accept_charset": "%{json.escape(req.http.Accept-Charset)}V",
+	"cache_status": "%{regsub(fastly_info.state, '^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*', '\\2\\3') }V"
+}</textarea>
                     <div class="admin__field-note">
                         A suggested format string appears by default.
                         See <a target="_blank" href="https://docs.fastly.com/en/guides/setting-up-remote-log-streaming" rel="noopener noreferrer" class="external-link">Fastly's log files docs</a>,
@@ -1433,7 +1480,8 @@
                     <span><?php /* @noEscape */ echo __("Log format") ?></span>
                 </label>
                 <div class="admin__field-control">
-                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text"></textarea>
+                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text">
+"%h %l %u %t \"%r\" %>s %b"</textarea>
                     <div class="admin__field-note">
                         An Apache-style string or VCL variables to use for log formatting (the Apache Common Log format string appears by default).
                         See <a target="_blank" href="https://docs.fastly.com/en/guides/setting-up-remote-log-streaming" rel="noopener noreferrer" class="external-link">Fastly's log files docs</a>,
@@ -1702,7 +1750,8 @@
                     <span><?php /* @noEscape */ echo __("Log format") ?></span>
                 </label>
                 <div class="admin__field-control">
-                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text"></textarea>
+                    <textarea rows="6" name="log_endpoint[format]" required="required" id="log_endpoint[format]" class="admin__control-text">
+"%h %l %u %t \"%r\" %>s %b"</textarea>
                     <div class="admin__field-note">
                         An Apache-style string or VCL variables to use for log formatting (the Apache Common Log format string appears by default).
                         See <a target="_blank" href="https://docs.fastly.com/en/guides/setting-up-remote-log-streaming" rel="noopener noreferrer" class="external-link">Fastly's log files docs</a>,


### PR DESCRIPTION
- Implement proper JSON encoding/decoding of log format to send to the API and to display on the browser
- Implement log format default samples as Fastly.com, corrected as valid JSON