### PR TITLE
feature/M095M01A-7_8 [MAGENTO 2] Allow configuration of edge modules …

### DIFF
--- a/Console/Command/ConfigImportCommand.php
+++ b/Console/Command/ConfigImportCommand.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Fastly CDN for Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Fastly CDN for Magento End User License Agreement
+ * that is bundled with this package in the file LICENSE_FASTLY_CDN.txt.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Fastly CDN to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Fastly
+ * @package     Fastly_Cdn
+ * @copyright   Copyright (c) 2016 Fastly, Inc. (http://www.fastly.com)
+ * @license     BSD, see LICENSE_FASTLY_CDN.txt
+ */
+namespace Fastly\Cdn\Console\Command;
+
+use LightnCandy\LightnCandy;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Class ConfigImportCommand
+ *
+ * @package Fastly\Cdn\Console\Command
+ */
+class ConfigImportCommand extends Command
+{
+    /**
+     * @var \Fastly\Cdn\Model\Api
+     */
+    private $api;
+    /**
+     * @var \Fastly\Cdn\Helper\Vcl
+     */
+    private $vcl;
+    /**
+     * @var \Fastly\Cdn\Model\Importer
+     */
+    private $importer;
+
+    public function __construct(
+        \Fastly\Cdn\Model\Api $api,
+        \Fastly\Cdn\Helper\Vcl $vcl,
+        \Fastly\Cdn\Model\Importer $importer,
+        $name = null
+    ) {
+        parent::__construct($name);
+        $this->api = $api;
+        $this->vcl = $vcl;
+        $this->importer = $importer;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName('fastly:conf:import')
+            ->setDescription('Import Fastly configuration');
+
+        $this->addOption(
+            'activate',
+            'a',
+            InputOption::VALUE_OPTIONAL,
+            'Activate version once improted.',
+            false
+        );
+
+        $this->addArgument(
+            'json',
+            InputOption::VALUE_REQUIRED,
+            'JSON file with configurations.'
+        );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) // @codingStandardsIgnoreLine - required by parent class
+    {
+        try {
+            $file = $input->getArgument('json');
+            $data = json_decode(file_get_contents($file));
+            if (!$data) {
+                $output->writeln("<error>Invalid file structure</error>");
+                return;
+            }
+
+            $clone = $this->getClonedVersion();
+
+            $output->writeln('Importing Edge ACLs');
+            $this->importer->importEdgeAcls($clone->number, $data->edge_acls);
+
+            $output->writeln('Importing Edge Dictionaries');
+            $this->importer->importEdgeDictionaries($clone->number, $data->edge_dictionaries);
+
+            $output->writeln('Importing Edge Modules');
+            $this->importer->importActiveEdgeModules($clone->number, $data->active_modules);
+
+            if ($input->getOption('activate')) {
+                $this->api->activateVersion($clone->number);
+            }
+
+            $this->api->addComment($clone->number, ['comment' => 'Magento Module imported multiple configurations.']);
+
+            $output->writeln('<info>Configurations imported successfully.</info>');
+
+        } catch (\Exception $e) {
+            $output->writeln("<error>{$e->getMessage()}</error>");
+        }
+    }
+
+    /**
+     * @return bool|mixed
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function getClonedVersion()
+    {
+        $service = $this->api->checkServiceDetails();
+        $currActiveVersion = $this->vcl->getCurrentVersion($service->versions);
+        return $this->api->cloneVersion($currActiveVersion);
+    }
+}

--- a/Controller/Adminhtml/FastlyCdn/ImportExport/SaveImportData.php
+++ b/Controller/Adminhtml/FastlyCdn/ImportExport/SaveImportData.php
@@ -101,7 +101,7 @@ class SaveImportData extends Action
 
             $this->importer->importEdgeAcls($clone->number, $data->edge_acls);
             $this->importer->importEdgeDictionaries($clone->number, $data->edge_dictionaries);
-            $this->importer->importActiveEdgeModules($clone->number, $data->active_modules, $this->getRequest()->getParam('active_modules_snippets'));
+            $this->importer->importActiveEdgeModules($clone->number, $data->active_modules);
 
 
             if ($this->getRequest()->getParam('activate_flag')) {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "magento/module-store": ">=100.0.0",
         "magento/module-page-cache": ">=100.0.0",
         "magento/module-cache-invalidate": ">=100.0.0",
-        "magento/framework": ">=101.0.0"
+        "magento/framework": ">=101.0.0",
+        "zordius/lightncandy": "^1.2"
     },
     "type": "magento2-module",
     "version": "1.2.129",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -38,6 +38,7 @@
             <argument name="commands" xsi:type="array">
                 <item name="EnableCommand" xsi:type="object">Fastly\Cdn\Console\Command\EnableCommand</item>
                 <item name="generateFastlyVclCommand" xsi:type="object">Fastly\Cdn\Console\Command\GenerateVclCommand</item>
+                <item name="ImportConfigCommand" xsi:type="object">Fastly\Cdn\Console\Command\ConfigImportCommand</item>
                 <item name="SerializeToJson" xsi:type="object">Fastly\Cdn\Console\Command\SerializeToJson</item>
                 <item name="JsonToSerialize" xsi:type="object">Fastly\Cdn\Console\Command\JsonToSerialize</item>
                 <item name="ConfigGetCommand" xsi:type="object">Fastly\Cdn\Console\Command\ConfigGetCommand</item>

--- a/view/adminhtml/web/js/import-export-renderer.js
+++ b/view/adminhtml/web/js/import-export-renderer.js
@@ -87,14 +87,6 @@ define(
                 return html;
             },
 
-            renderActiveEdgeModulesSnippets: function (data) {
-                let html = '';
-                $.each(data, function (index, moduleSnippet) {
-                    html += `<input type="hidden" name="active_modules_snippets[${moduleSnippet.module_id}]" value="${escape(moduleSnippet.snippet)}" />`;
-                });
-                return html;
-            },
-
             renderAdminPathTimeout: function (data) {
                 let html = this._renderTitle('Admin Path Timeout');
                 html += `<div class="admin__field field">


### PR DESCRIPTION
…via CLI

- Add command `bin/magento fastly:conf:import` which takes a JSON file path as arg
- Process JSON file with Importer (same as web import)
- Refactor Importer javascript to remove snippet parsing and use of Handelbars processor
- Refactor Importer php to implement snippet parsing and use lightncandy processor